### PR TITLE
Fix words/memes selection in captcha

### DIFF
--- a/src/routes/utils/captcha.rb
+++ b/src/routes/utils/captcha.rb
@@ -10,7 +10,7 @@ def make_text
 		127 + Random.rand(127);
 	end
 	word = -> () do
-		Random.rand(4) ? Words.sample : Memes.sample
+		Random.rand(4) != 0 ? Words.sample : Memes.sample
 	end
 	text = "#{word.call} #{word.call} #{word.call}"
 	realtext = ""


### PR DESCRIPTION
The current captcha system uses a random number between 0 and 3 to determine whether or not to use a string from the Words array or from the Memes array for each part of the captcha. However, all numbers in that range evaluate to true in Ruby. Therefore, only the Words array is used. This change fixes that, giving each part of the captcha a 25% chance to be selected from the Memes array.