### PR TITLE
Fix hidden posts metadata on archived threads pages

### DIFF
--- a/src/views/thread.erb
+++ b/src/views/thread.erb
@@ -124,7 +124,10 @@
           }
           var ol = function ol() {
             var submit_function = function() { submit_form(document.getElementById("form"), "/reply") };
-            document.getElementById("submit").addEventListener("click", submit_function);
+            var submit_el = document.getElementById("submit");
+            if (submit_el) {
+              submit_el.addEventListener("click", submit_function);
+            }
             var captcha = document.getElementById("captcha");
             if (captcha) {
               captcha.addEventListener("keydown", function(e) {


### PR DESCRIPTION
There is an error when JS script tried to bind an event handler to form submit element (regression from https://github.com/dangeru/awoo/commit/656a12ab19e7f84efea991685a5d114505fd7c78), but there is no form at archived thread page, and posts' metadata was hidden.

![Screenshot demonstrating this issue](https://user-images.githubusercontent.com/53416430/65388647-00c16880-dd78-11e9-8ff0-d80d8c126dc7.png)

Now there is a check for `submit` element. If it doesn't exist, adding event listener for form won't run, resulting in no error, and code will proceed executing.